### PR TITLE
Fixes issue 1

### DIFF
--- a/bc.sh
+++ b/bc.sh
@@ -34,7 +34,7 @@ run_test "1" "5 % 2"
 
 # Division by zero test (expect an error)
 division_by_zero=$(echo "scale=2; 1 / 0" | bc 2>&1)
-if [[ "$division_by_zero" == *"division by zero"* ]]; then
+if [[ "$division_by_zero" == *"Divide by zero"* ]]; then
     echo "Test passed: Division by zero correctly handled"
 else
     echo "Test failed: Division by zero not handled correctly"


### PR DESCRIPTION
if [[ "$division_by_zero" == *"division by zero"* ]]; then                        
This line checks if the output of the variable division_by_zero has the string "division by zero". However, the output of division_by_zero is Runtime error (func=(main), adr=3): Divide by zero. Clearly, we need to match the variable with Divide by zero.  